### PR TITLE
Add RVO content sync and HF upload

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,8 @@
-name: Weekly RVO Blog Sync
+name: Bi-daily RVO Content Sync
 
 on:
+  schedule:
+    - cron: '0 0 */2 * *'
   workflow_dispatch:
 
 jobs:
@@ -20,11 +22,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run blog sync
-        run: python rvo_blog_sync.py
-
-      - name: Upload data artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: blog-data
-          path: data/rvo_blogs.jsonl
+      - name: Run content sync
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_DATASET_REPO: ${{ secrets.HF_DATASET_REPO }}
+        run: python rvo_content_sync.py

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-# Dutch RVO Blog Scraper
+# Dutch RVO Content Sync
 
-This project pulls all Dutch public RVO blog posts and prepares them for integration with Hugging Face Datasets.
+This project gathers public content from the Dutch RVO website and publishes it as a dataset on Hugging Face.
 
 ## Structure
 
-Each blog post is split into three dataset entries:
-- `title`
-- `summary`
-- `content` (currently empty unless full scraping is added)
+Every item (blog, event, article, etc.) is represented by three separate dataset entries containing its title, summary and full content. Each entry is stored as JSON lines in the following format:
 
-Each entry is stored as:
 ```json
 {
   "url": "...",
   "content": "...",
-  "source": "RVO-Blogs",
-  "type": "title" | "summary" | "content"
+  "source": "RVO Blogs | Evenementen | Nieuws | Onderwerpen | Overzichten | Praktijkverhalen | Subsidies en financiering"
 }
 ```
 
@@ -23,11 +18,11 @@ Each entry is stored as:
 
 ```bash
 pip install -r requirements.txt
-python rvo_blog_sync.py
+python rvo_content_sync.py
 ```
+
+Set the `HF_TOKEN` and optionally `HF_DATASET_REPO` environment variables to upload the data to your Hugging Face account.
 
 ## GitHub Actions
 
-This repo is configured to automatically fetch new blog posts every Monday.
-
-To trigger manually, go to GitHub → Actions → *Weekly RVO Blog Sync* → Run workflow.
+The repository contains a workflow that synchronizes the content every two days and uploads the dataset to Hugging Face.

--- a/rvo_content_sync.py
+++ b/rvo_content_sync.py
@@ -1,0 +1,109 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+from huggingface_hub import HfApi
+
+# Mapping of content sources to their Open Data API endpoints
+ENDPOINTS = {
+    "RVO Blogs": "https://www.rvo.nl/api/v1/opendata/blogs",
+    "Evenementen": "https://www.rvo.nl/api/v1/opendata/events",
+    "Nieuws": "https://www.rvo.nl/api/v1/opendata/articles",
+    "Onderwerpen": "https://www.rvo.nl/api/v1/opendata/subjects",
+    "Overzichten": "https://www.rvo.nl/api/v1/opendata/summary",
+    "Praktijkverhalen": "https://www.rvo.nl/api/v1/opendata/showcases",
+    "Subsidies en financiering": "https://www.rvo.nl/api/v1/opendata/subsidies",
+}
+
+BASE_URL = "https://www.rvo.nl"
+DATA_DIR = Path("data")
+DATA_DIR.mkdir(exist_ok=True)
+DATA_FILE = DATA_DIR / "rvo_content.jsonl"
+
+# Configure your Hugging Face dataset repo
+HF_DATASET_REPO = os.environ.get("HF_DATASET_REPO", "username/rvo-content")
+HF_TOKEN = os.environ.get("HF_TOKEN")
+
+
+def fetch_items(url: str) -> List[Dict]:
+    """Fetch JSON items from the given endpoint."""
+    response = requests.get(url)
+    response.raise_for_status()
+    data = response.json()
+    # Some endpoints may nest results inside "items"
+    if isinstance(data, dict):
+        return data.get("items") or data.get("data") or []
+    return data
+
+
+def make_entries(item: Dict, source: str) -> List[Dict]:
+    """Convert one API item into up to three dataset entries."""
+    entries = []
+    url = item.get("url") or item.get("link") or ""
+    if url and not url.startswith("http"):
+        url = BASE_URL + url
+
+    title = item.get("title") or ""
+    summary = item.get("intro") or item.get("summary") or ""
+    content = item.get("body") or item.get("content") or ""
+
+    for text in [title, summary, content]:
+        if text:
+            entries.append({"url": url, "content": text.strip(), "source": source})
+    return entries
+
+
+def load_existing() -> set:
+    """Load existing (url, content) pairs to avoid duplicates."""
+    seen = set()
+    if DATA_FILE.exists():
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                entry = json.loads(line)
+                seen.add((entry["url"], entry["content"]))
+    return seen
+
+
+def append_entries(new_entries: List[Dict]) -> None:
+    seen = load_existing()
+    with open(DATA_FILE, "a", encoding="utf-8") as f:
+        for entry in new_entries:
+            key = (entry["url"], entry["content"])
+            if key not in seen:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                seen.add(key)
+
+
+def push_to_hf() -> None:
+    """Upload the JSONL file to Hugging Face."""
+    if not HF_TOKEN:
+        print("HF_TOKEN not set; skipping upload")
+        return
+    api = HfApi(token=HF_TOKEN)
+    api.upload_file(
+        path_or_fileobj=str(DATA_FILE),
+        path_in_repo=DATA_FILE.name,
+        repo_id=HF_DATASET_REPO,
+        repo_type="dataset",
+    )
+
+
+def main() -> None:
+    all_new_entries = []
+    for source, url in ENDPOINTS.items():
+        try:
+            items = fetch_items(url)
+        except Exception as e:
+            print(f"Failed to fetch {source}: {e}")
+            continue
+        for item in items:
+            all_new_entries.extend(make_entries(item, source))
+
+    append_entries(all_new_entries)
+    push_to_hf()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `rvo_content_sync.py` to download all RVO content sources and upload JSONL data to HuggingFace
- update workflow to run every 2 days and execute the new script
- refresh README with new instructions

## Testing
- `python -m py_compile rvo_content_sync.py`
- `python -m py_compile rvo_blog_sync.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444390a9888329b65adc807f7f8d14