### PR TITLE
Fix dataset repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ pip install -r requirements.txt
 python rvo_content_sync.py
 ```
 
-Set the `HF_TOKEN` and optionally `HF_DATASET_REPO` environment variables to upload the data to your Hugging Face account.
+Set the `HF_TOKEN` environment variable to enable uploading to Hugging Face.
+The dataset will be pushed to `vGassen/Dutch-RVO-blogs` by default, but you can
+override this by setting the `HF_DATASET_REPO` environment variable.
 
 ## GitHub Actions
 

--- a/rvo_content_sync.py
+++ b/rvo_content_sync.py
@@ -22,8 +22,10 @@ DATA_DIR = Path("data")
 DATA_DIR.mkdir(exist_ok=True)
 DATA_FILE = DATA_DIR / "rvo_content.jsonl"
 
-# Configure your Hugging Face dataset repo
-HF_DATASET_REPO = os.environ.get("HF_DATASET_REPO", "username/rvo-content")
+# Configure your Hugging Face dataset repo. Treat an empty environment variable
+# as if it was not provided so the default is used. The default repository is
+# ``vGassen/Dutch-RVO-blogs``.
+HF_DATASET_REPO = os.environ.get("HF_DATASET_REPO") or "vGassen/Dutch-RVO-blogs"
 HF_TOKEN = os.environ.get("HF_TOKEN")
 
 


### PR DESCRIPTION
## Summary
- update default HF dataset repo to vGassen/Dutch-RVO-blogs
- document default repo in README

## Testing
- `python -m py_compile rvo_content_sync.py rvo_blog_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68468cbcad2c8329abf9e8a3627eef53