### PR TITLE
Handle missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+data/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Every item (blog, event, article, etc.) is represented by three separate dataset
 ## Running locally
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt  # optional: only needed for upload features
 python rvo_content_sync.py
 ```
 


### PR DESCRIPTION
## Summary
- add `.gitignore`
- use `urllib` instead of `requests`
- avoid failing when `huggingface_hub` isn't installed
- clarify dependency install in README

## Testing
- `python -m py_compile rvo_content_sync.py`
- `python rvo_content_sync.py` *(fails to fetch due to no network, but handles errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac922afc8329b1bdccb80d6f5f79