### PR TITLE
Handle missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+data/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ This project gathers public content from the Dutch RVO website and publishes it 
 
 ## Structure
 
-Every item (blog, event, article, etc.) is represented by three separate dataset entries containing its title, summary and full content. Each entry is stored as JSON lines in the following format:
+Each public item from RVO is converted into one or more simple entries. For every
+source (blogs, events, news, etc.) we create a row for the title, the summary
+and the full text.  Every row only contains the URL of the item, the extracted
+text and the source name.  The dataset therefore consists of many short
+snippets rather than a single object per page.
+
+Entries are stored in a JSON Lines file with the following format:
 
 ```json
 {
@@ -17,13 +23,14 @@ Every item (blog, event, article, etc.) is represented by three separate dataset
 ## Running locally
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt  # optional: only needed for upload features
 python rvo_content_sync.py
 ```
 
 Set the `HF_TOKEN` environment variable to enable uploading to Hugging Face.
-The dataset will be pushed to `vGassen/Dutch-RVO-blogs` by default, but you can
-override this by setting the `HF_DATASET_REPO` environment variable.
+By default the data is pushed to `vGassen/Dutch-RVO-blogs`, even though it
+contains more than just blogs.  You can override the destination by setting the
+`HF_DATASET_REPO` environment variable.
 
 ## GitHub Actions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4
-requests
 datasets
 huggingface_hub


### PR DESCRIPTION
## Summary
- add `.gitignore`
- use `urllib` instead of `requests`
- avoid failing when `huggingface_hub` isn't installed
- document dataset structure and remove unused dependency

## Testing
- `python -m py_compile rvo_content_sync.py`
- `python rvo_content_sync.py` *(fails to fetch due to no network, but handles errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac922afc8329b1bdccb80d6f5f79